### PR TITLE
Fix node client usage for batch requests.

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -378,7 +378,7 @@ var addresses = [
   '17015 Walnut Grove Drive, Morgan Hill CA'
 ];
 
-geocodio.geocode(addresses, function(err, locations) {
+geocodio.post('geocode', addresses, function(err, locations) {
     if (err) throw err;
 
     console.log(locations);


### PR DESCRIPTION
Using the latest version of the npm package `geocodio`, the syntax shown in the docs is incorrect. I'm guessing this is the case elsewhere in the js examples in the docs, and would be worth checking...