### PR TITLE
add-library-tidygeocoder

### DIFF
--- a/source.html.md
+++ b/source.html.md
@@ -180,6 +180,11 @@ HIPAA-->
     <td><i class="fa fa-minus"></i></td>
   </tr>
   <tr>
+    <td><strong>R</strong></td>
+    <td><a href="https://jessecambon.github.io/tidygeocoder" target="_blank">jessecambon/tidygeocoder</a> by <a href="https://github.com/jessecambon" target="_blank">jessecambon</a></td>
+    <td><i class="fa fa-minus"></i></td>
+  </tr>
+  <tr>
     <td><strong>C#</strong></td>
     <td><a href="https://github.com/snake-plissken/cSharpGeocodio" target="_blank">snake-plissken/cSharpGeocodio</a> by <a href="https://github.com/snake-plissken" target="_blank">Frank Deasey</a></td>
     <td><i class="fa fa-minus"></i></td>


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Adding a listing for the [R package tidygeocoder](https://jessecambon.github.io/tidygeocoder/index.html) which just added support for geocodio with release v1.0.0. 