### PR TITLE
Updating Docs to Add Suite/Apt# Example and CD-0/CD-98 Note

### DIFF
--- a/source.html.md
+++ b/source.html.md
@@ -2232,6 +2232,9 @@ The field returns the full name of the Congressional district, the district numb
 The list of legislators is always ordered with Representative first then Senators.
 </aside>
 
+<aside class="notice">
+If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+</aside>
 
 ### OCD Identifiers
 

--- a/source.html.md
+++ b/source.html.md
@@ -514,6 +514,62 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
+> To geocode an address with a Suite/Apartment Number 
+
+```shell
+  curl "https://api.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
+```
+
+> Example response with Suite/Apartment Number
+
+```json
+{
+  "input": {
+    "address_components": {
+      "number": "2800",
+      "street": "Clarendon",
+      "suffix": "Blvd",
+      "secondaryunit": "Ste",
+      "secondarynumber": "R500",
+      "formatted_street": "Clarendon Blvd",
+      "city": "Arlington",
+      "state": "VA",
+      "zip": "22201",
+      "country": "US"
+    },
+    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "2800",
+        "street": "Clarendon",
+        "suffix": "Blvd",
+        "secondaryunit": "Ste",
+        "secondarynumber": "R500",
+        "formatted_street": "Clarendon Blvd",
+        "city": "Arlington",
+        "county": "Arlington County",
+        "state": "VA",
+        "zip": "22201",
+        "country": "US"
+      },
+      "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201",
+      "location": {
+        "lat": 38.887455,
+        "lng": -77.092018
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Arlington"
+    }
+  ]
+}
+```
+
+**Suite/Apartment Secondary Unity Response**
+
+If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
 
 ## Batch geocoding
 

--- a/source.html.md
+++ b/source.html.md
@@ -514,13 +514,15 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
-> To geocode an address with a Suite/Apartment Number 
+### Geocoding with Unit Numbers
+
+> To geocode an address with a Unit Number 
 
 ```shell
   curl "https://api.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
 ```
 
-> Example response with Suite/Apartment Number
+> Example response with Unit Number
 
 ```json
 {
@@ -537,7 +539,7 @@ The `fields` parameter is still supported when the `simple` output format is sel
       "zip": "22201",
       "country": "US"
     },
-    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+    "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201"
   },
   "results": [
     {
@@ -567,9 +569,13 @@ The `fields` parameter is still supported when the `simple` output format is sel
 }
 ```
 
-**Suite/Apartment Secondary Unity Response**
-
 If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
+
+**For US addresses:** The `secondaryunit` value will be standardized based on USPS records, if the unit number is deemed mailable and valid.
+
+E.g. if the unit number is inputted as `#R500`, the outputted value will be `Ste R500`.
+
+In order to verify that the unit number is valid per USPS, you can request the [`zip4`](#usps-zip-4) field append and check the `exact_match` value. If it is set to `true` it means that the unit number is accepted by USPS.
 
 ## Batch geocoding
 
@@ -2233,7 +2239,9 @@ The list of legislators is always ordered with Representative first then Senator
 </aside>
 
 <aside class="notice">
-If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+Per U.S. Census Bureau specifications, the following rules apply:<br />
+States with a single congressional district, will return a special "district_number" of 0 (i.e. Vermont).<br />
+Districts with non-voting delegates will return a special "district_number" of 98 (i.e. Washington DC).
 </aside>
 
 ### OCD Identifiers

--- a/source/enterprise/index.html.md
+++ b/source/enterprise/index.html.md
@@ -10,7 +10,7 @@ language_tabs:
   - clojure: Clojure
 
 toc_footers:
- - <a href="https://dash.geocod.io">Sign Up for an API Key</a>
+ - <a href="https://dash.enterprise.geocod.io">Sign Up for an API Key</a>
  - <a href="https://www.geocod.io/terms-of-use/">Terms of Use</a>
  - <a href="https://github.com/Geocodio/openapi-spec" target="_blank">OpenAPI Spec</a>
 
@@ -70,11 +70,11 @@ We will do our best to assist in online chat or email, but may not be able to he
 
 Some of the libraries are featured here with basic examples, but please make sure to check out the full documentation for the individual libraries (linked below).
 
-<!--ENTERPRISE
+
   <aside class="warning">
     Please consult the individual library documentation to ensure that you are using the <strong>api.enterprise.geocod.io</strong> hostname instead of the regular <strong>api.enterprise.geocod.io</strong> hostname.
   </aside>
-ENTERPRISE-->
+
 
 <table class="table">
   <tbody><tr>
@@ -220,14 +220,14 @@ from geocodio import GeocodioClient
 client = GeocodioClient(YOUR_API_KEY)
 ```
 
-<!--ENTERPRISE
+
 ```php
 <?php
 $geocoder = new Geocodio\Geocodio();
 $geocoder->setApiKey('YOUR_API_KEY');
 $geocoder->setHostname('api.enterprise.geocod.io');
 ```
-ENTERPRISE-->
+
 
 <!--DEFAULT
 ```php
@@ -246,7 +246,7 @@ const geocoder = new Geocodio('YOUR_API_KEY');
 ```
 DEFAULT-->
 
-<!--ENTERPRISE
+
 ```javascript
 const Geocodio = require('geocodio-library-node');
 const geocoder = new Geocodio('YOUR_API_KEY', 'api.enterprise.geocod.io');
@@ -255,7 +255,7 @@ const geocoder = new Geocodio('YOUR_API_KEY', 'api.enterprise.geocod.io');
 // GEOCODIO_API_KEY=YOUR_API_KEY
 // GEOCODIO_HOSTNAME=api.enterprise.geocod.io
 ```
-ENTERPRISE-->
+
 
 ```clojure
 (ns my.ns
@@ -265,7 +265,7 @@ ENTERPRISE-->
 ;; or with each request using the :api_key parameter
 ```
 
-All requests require an API key. You can [register here](https://dash.geocod.io) to get your own API key.
+All requests require an API key. You can [register here](https://dash.enterprise.geocod.io) to get your own API key.
 
 The API key must be included in all requests using the `?api_key=YOUR_API_KEY` query parameter.
 
@@ -274,7 +274,7 @@ Accounts can have multiple API keys. This can be useful if you're working on sev
 You can also download a CSV of usage and fees per API key.
 
 <aside class="warning">
-Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.geocod.io" target="_blank">Geocodio dashboard</a>.
+Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.enterprise.geocod.io" target="_blank">Geocodio dashboard</a>.
 </aside>
 
 <!--DEFAULT
@@ -284,15 +284,15 @@ Make sure to replace YOUR_API_KEY with your personal API key found on the <a hre
 
 ```json
 {
-  "error": "This API key does not have permission to access this feature. API key permissions can be changed in the Geocodio dashboard at https:\/\/dash.geocod.io\/apikey"
+  "error": "This API key does not have permission to access this feature. API key permissions can be changed in the Geocodio dashboard at https:\/\/dash.enterprise.geocod.io\/apikey"
 }
 ```
 
 Per default, an API key can only access the single and batch geocoding API endpoints. These endpoints are write-only which means that a lost API key can not be used to retreive geocoded data from your account.
 
-For security reasons, additional permissions has to be assigned to the API key when using the [lists API](#geocoding-lists). This can be done in the [Geocodio dashboard](https://dash.geocod.io/apikey). We recommend creating separate API keys for geocoding endpoints and for `GET`/`DELETE` access to lists.
+For security reasons, additional permissions has to be assigned to the API key when using the [lists API](#geocoding-lists). This can be done in the [Geocodio dashboard](https://dash.enterprise.geocod.io/apikey). We recommend creating separate API keys for geocoding endpoints and for `GET`/`DELETE` access to lists.
 
-[![List of API key permissions with default values selected](./images/permissions.png)](https://dash.geocod.io/apikey)
+[![List of API key permissions with default values selected](./images/permissions.png)](https://dash.enterprise.geocod.io/apikey)
 
 *List of API key permissions with default values selected*
 
@@ -514,13 +514,15 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
-> To geocode an address with a Suite/Apartment Number 
+### Geocoding with Unit Numbers
+
+> To geocode an address with a Unit Number 
 
 ```shell
   curl "https://api.enterprise.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
 ```
 
-> Example response with Suite/Apartment Number
+> Example response with Unit Number
 
 ```json
 {
@@ -537,7 +539,7 @@ The `fields` parameter is still supported when the `simple` output format is sel
       "zip": "22201",
       "country": "US"
     },
-    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+    "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201"
   },
   "results": [
     {
@@ -567,9 +569,13 @@ The `fields` parameter is still supported when the `simple` output format is sel
 }
 ```
 
-**Suite/Apartment Secondary Unity Response**
-
 If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
+
+**For US addresses:** The `secondaryunit` value will be standardized based on USPS records, if the unit number is deemed mailable and valid.
+
+E.g. if the unit number is inputted as `#R500`, the outputted value will be `Ste R500`.
+
+In order to verify that the unit number is valid per USPS, you can request the [`zip4`](#usps-zip-4) field append and check the `exact_match` value. If it is set to `true` it means that the unit number is accepted by USPS.
 
 ## Batch geocoding
 
@@ -2353,7 +2359,9 @@ The list of legislators is always ordered with Representative first then Senator
 </aside>
 
 <aside class="notice">
-If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+Per U.S. Census Bureau specifications, the following rules apply:<br />
+States with a single congressional district, will return a special "district_number" of 0 (i.e. Vermont).<br />
+Districts with non-voting delegates will return a special "district_number" of 98 (i.e. Washington DC).
 </aside>
 
 ### OCD Identifiers
@@ -5791,7 +5799,7 @@ An extra `address_components_secondary` property will be exposed for intersectio
 
 ```json
 {
-  "error": "You can't make this request as it is above your daily maximum. You can configure billing at https://dash.geocod.io"
+  "error": "You can't make this request as it is above your daily maximum. You can configure billing at https://dash.enterprise.geocod.io"
 }
 ```
 

--- a/source/enterprise/index.html.md
+++ b/source/enterprise/index.html.md
@@ -10,7 +10,7 @@ language_tabs:
   - clojure: Clojure
 
 toc_footers:
- - <a href="https://dash.enterprise.geocod.io">Sign Up for an API Key</a>
+ - <a href="https://dash.geocod.io">Sign Up for an API Key</a>
  - <a href="https://www.geocod.io/terms-of-use/">Terms of Use</a>
  - <a href="https://github.com/Geocodio/openapi-spec" target="_blank">OpenAPI Spec</a>
 
@@ -70,11 +70,11 @@ We will do our best to assist in online chat or email, but may not be able to he
 
 Some of the libraries are featured here with basic examples, but please make sure to check out the full documentation for the individual libraries (linked below).
 
-
+<!--ENTERPRISE
   <aside class="warning">
     Please consult the individual library documentation to ensure that you are using the <strong>api.enterprise.geocod.io</strong> hostname instead of the regular <strong>api.enterprise.geocod.io</strong> hostname.
   </aside>
-
+ENTERPRISE-->
 
 <table class="table">
   <tbody><tr>
@@ -220,14 +220,14 @@ from geocodio import GeocodioClient
 client = GeocodioClient(YOUR_API_KEY)
 ```
 
-
+<!--ENTERPRISE
 ```php
 <?php
 $geocoder = new Geocodio\Geocodio();
 $geocoder->setApiKey('YOUR_API_KEY');
 $geocoder->setHostname('api.enterprise.geocod.io');
 ```
-
+ENTERPRISE-->
 
 <!--DEFAULT
 ```php
@@ -246,7 +246,7 @@ const geocoder = new Geocodio('YOUR_API_KEY');
 ```
 DEFAULT-->
 
-
+<!--ENTERPRISE
 ```javascript
 const Geocodio = require('geocodio-library-node');
 const geocoder = new Geocodio('YOUR_API_KEY', 'api.enterprise.geocod.io');
@@ -255,7 +255,7 @@ const geocoder = new Geocodio('YOUR_API_KEY', 'api.enterprise.geocod.io');
 // GEOCODIO_API_KEY=YOUR_API_KEY
 // GEOCODIO_HOSTNAME=api.enterprise.geocod.io
 ```
-
+ENTERPRISE-->
 
 ```clojure
 (ns my.ns
@@ -265,7 +265,7 @@ const geocoder = new Geocodio('YOUR_API_KEY', 'api.enterprise.geocod.io');
 ;; or with each request using the :api_key parameter
 ```
 
-All requests require an API key. You can [register here](https://dash.enterprise.geocod.io) to get your own API key.
+All requests require an API key. You can [register here](https://dash.geocod.io) to get your own API key.
 
 The API key must be included in all requests using the `?api_key=YOUR_API_KEY` query parameter.
 
@@ -274,7 +274,7 @@ Accounts can have multiple API keys. This can be useful if you're working on sev
 You can also download a CSV of usage and fees per API key.
 
 <aside class="warning">
-Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.enterprise.geocod.io" target="_blank">Geocodio dashboard</a>.
+Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.geocod.io" target="_blank">Geocodio dashboard</a>.
 </aside>
 
 <!--DEFAULT
@@ -284,15 +284,15 @@ Make sure to replace YOUR_API_KEY with your personal API key found on the <a hre
 
 ```json
 {
-  "error": "This API key does not have permission to access this feature. API key permissions can be changed in the Geocodio dashboard at https:\/\/dash.enterprise.geocod.io\/apikey"
+  "error": "This API key does not have permission to access this feature. API key permissions can be changed in the Geocodio dashboard at https:\/\/dash.geocod.io\/apikey"
 }
 ```
 
 Per default, an API key can only access the single and batch geocoding API endpoints. These endpoints are write-only which means that a lost API key can not be used to retreive geocoded data from your account.
 
-For security reasons, additional permissions has to be assigned to the API key when using the [lists API](#geocoding-lists). This can be done in the [Geocodio dashboard](https://dash.enterprise.geocod.io/apikey). We recommend creating separate API keys for geocoding endpoints and for `GET`/`DELETE` access to lists.
+For security reasons, additional permissions has to be assigned to the API key when using the [lists API](#geocoding-lists). This can be done in the [Geocodio dashboard](https://dash.geocod.io/apikey). We recommend creating separate API keys for geocoding endpoints and for `GET`/`DELETE` access to lists.
 
-[![List of API key permissions with default values selected](./images/permissions.png)](https://dash.enterprise.geocod.io/apikey)
+[![List of API key permissions with default values selected](./images/permissions.png)](https://dash.geocod.io/apikey)
 
 *List of API key permissions with default values selected*
 
@@ -514,6 +514,62 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
+> To geocode an address with a Suite/Apartment Number 
+
+```shell
+  curl "https://api.enterprise.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
+```
+
+> Example response with Suite/Apartment Number
+
+```json
+{
+  "input": {
+    "address_components": {
+      "number": "2800",
+      "street": "Clarendon",
+      "suffix": "Blvd",
+      "secondaryunit": "Ste",
+      "secondarynumber": "R500",
+      "formatted_street": "Clarendon Blvd",
+      "city": "Arlington",
+      "state": "VA",
+      "zip": "22201",
+      "country": "US"
+    },
+    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "2800",
+        "street": "Clarendon",
+        "suffix": "Blvd",
+        "secondaryunit": "Ste",
+        "secondarynumber": "R500",
+        "formatted_street": "Clarendon Blvd",
+        "city": "Arlington",
+        "county": "Arlington County",
+        "state": "VA",
+        "zip": "22201",
+        "country": "US"
+      },
+      "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201",
+      "location": {
+        "lat": 38.887455,
+        "lng": -77.092018
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Arlington"
+    }
+  ]
+}
+```
+
+**Suite/Apartment Secondary Unity Response**
+
+If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
 
 ## Batch geocoding
 
@@ -5732,7 +5788,7 @@ An extra `address_components_secondary` property will be exposed for intersectio
 
 ```json
 {
-  "error": "You can't make this request as it is above your daily maximum. You can configure billing at https://dash.enterprise.geocod.io"
+  "error": "You can't make this request as it is above your daily maximum. You can configure billing at https://dash.geocod.io"
 }
 ```
 

--- a/source/enterprise/index.html.md
+++ b/source/enterprise/index.html.md
@@ -2352,6 +2352,9 @@ The field returns the full name of the Congressional district, the district numb
 The list of legislators is always ordered with Representative first then Senators.
 </aside>
 
+<aside class="notice">
+If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+</aside>
 
 ### OCD Identifiers
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -229,22 +229,22 @@ $geocoder->setHostname('api.enterprise.geocod.io');
 ```
 ENTERPRISE-->
 
-<!--DEFAULT
+
 ```php
 <?php
 $geocoder = new Geocodio\Geocodio();
 $geocoder->setApiKey('YOUR_API_KEY');
 ```
-DEFAULT-->
 
-<!--DEFAULT
+
+
 ```javascript
 const Geocodio = require('geocodio-library-node');
 const geocoder = new Geocodio('YOUR_API_KEY');
 
 // You can also leave out the parameter and define the "GEOCODIO_API_KEY" environment variable instead
 ```
-DEFAULT-->
+
 
 <!--ENTERPRISE
 ```javascript
@@ -277,7 +277,7 @@ You can also download a CSV of usage and fees per API key.
 Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.geocod.io" target="_blank">Geocodio dashboard</a>.
 </aside>
 
-<!--DEFAULT
+
 # Permissions
 
 > A `403 Forbidden` HTTP status code is returned if the API key is valid, but does not have permission to access the requested endpoint
@@ -296,9 +296,9 @@ For security reasons, additional permissions has to be assigned to the API key w
 
 *List of API key permissions with default values selected*
 
-DEFAULT-->
 
-<!--DEFAULT
+
+
 # Overview
 
 The Geocodio API supports three different methods for processing your data. The method you choose will largely depend on your workflow and the amount of addresses or coordinates that you are looking to process.
@@ -312,7 +312,7 @@ Name                                  | Batch size         | Type         | Form
 [List geocoding](#geocoding-lists)    | Up to 10,000,000+  | Asynchronous | CSV/TSV/Excel    | <i class="fa fa-check"></i> | <i class="fa fa-check"></i>
 
 If in doubt, [single geocoding](#geocoding) is the simplest choice for many use cases.
-DEFAULT-->
+
 
 # Geocoding
 
@@ -514,13 +514,15 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
-> To geocode an address with a Suite/Apartment Number 
+### Geocoding with Unit Numbers
+
+> To geocode an address with a Unit Number 
 
 ```shell
   curl "https://api.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
 ```
 
-> Example response with Suite/Apartment Number
+> Example response with Unit Number
 
 ```json
 {
@@ -537,7 +539,7 @@ The `fields` parameter is still supported when the `simple` output format is sel
       "zip": "22201",
       "country": "US"
     },
-    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+    "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201"
   },
   "results": [
     {
@@ -567,9 +569,13 @@ The `fields` parameter is still supported when the `simple` output format is sel
 }
 ```
 
-**Suite/Apartment Secondary Unity Response**
-
 If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
+
+**For US addresses:** The `secondaryunit` value will be standardized based on USPS records, if the unit number is deemed mailable and valid.
+
+E.g. if the unit number is inputted as `#R500`, the outputted value will be `Ste R500`.
+
+In order to verify that the unit number is valid per USPS, you can request the [`zip4`](#usps-zip-4) field append and check the `exact_match` value. If it is set to `true` it means that the unit number is accepted by USPS.
 
 ## Batch geocoding
 
@@ -1268,7 +1274,7 @@ Parameter | Description
 `limit`   | Optional parameter. The maximum number of results to return. The default is no limit.
 
 
-<!--DEFAULT
+
 # Geocoding lists
 
 The lists API lets you upload and process spreadsheet with addresses or coordinates. Similar to the [spreadsheet feature](https://www.geocod.io/upload/) in the dashboard, the spreadsheet will be processed as a job on Geocodio's infrastructure and can be downloaded at a later time. While a spreadsheet is being processed it is possible to query the status and progress.
@@ -1859,7 +1865,7 @@ The spreadsheet data will always be deleted automatically after 72 hours if it i
 Parameter | Description
 --------- | -----------
 `api_key` | Your Geocodio API key
-DEFAULT-->
+
 
 # Fields
 
@@ -2145,9 +2151,9 @@ Parameter name                                                                  
 
 <aside class="success">
 This feature is available for both single and batch geocoding requests
-<!--DEFAULT
+
 as well as the lists API
-DEFAULT-->
+
 </aside>
 
 ## Congressional Districts
@@ -2353,7 +2359,9 @@ The list of legislators is always ordered with Representative first then Senator
 </aside>
 
 <aside class="notice">
-If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+Per U.S. Census Bureau specifications, the following rules apply:<br />
+States with a single congressional district, will return a special "district_number" of 0 (i.e. Vermont).<br />
+Districts with non-voting delegates will return a special "district_number" of 98 (i.e. Washington DC).
 </aside>
 
 ### OCD Identifiers

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -229,22 +229,22 @@ $geocoder->setHostname('api.enterprise.geocod.io');
 ```
 ENTERPRISE-->
 
-
+<!--DEFAULT
 ```php
 <?php
 $geocoder = new Geocodio\Geocodio();
 $geocoder->setApiKey('YOUR_API_KEY');
 ```
+DEFAULT-->
 
-
-
+<!--DEFAULT
 ```javascript
 const Geocodio = require('geocodio-library-node');
 const geocoder = new Geocodio('YOUR_API_KEY');
 
 // You can also leave out the parameter and define the "GEOCODIO_API_KEY" environment variable instead
 ```
-
+DEFAULT-->
 
 <!--ENTERPRISE
 ```javascript
@@ -277,7 +277,7 @@ You can also download a CSV of usage and fees per API key.
 Make sure to replace YOUR_API_KEY with your personal API key found on the <a href="https://dash.geocod.io" target="_blank">Geocodio dashboard</a>.
 </aside>
 
-
+<!--DEFAULT
 # Permissions
 
 > A `403 Forbidden` HTTP status code is returned if the API key is valid, but does not have permission to access the requested endpoint
@@ -296,9 +296,9 @@ For security reasons, additional permissions has to be assigned to the API key w
 
 *List of API key permissions with default values selected*
 
+DEFAULT-->
 
-
-
+<!--DEFAULT
 # Overview
 
 The Geocodio API supports three different methods for processing your data. The method you choose will largely depend on your workflow and the amount of addresses or coordinates that you are looking to process.
@@ -312,7 +312,7 @@ Name                                  | Batch size         | Type         | Form
 [List geocoding](#geocoding-lists)    | Up to 10,000,000+  | Asynchronous | CSV/TSV/Excel    | <i class="fa fa-check"></i> | <i class="fa fa-check"></i>
 
 If in doubt, [single geocoding](#geocoding) is the simplest choice for many use cases.
-
+DEFAULT-->
 
 # Geocoding
 
@@ -514,6 +514,62 @@ When `format` is set to `simple`, a very simple JSON structure is outputted, wit
 
 The `fields` parameter is still supported when the `simple` output format is selected, but the `limit` parameter has no effect.
 
+> To geocode an address with a Suite/Apartment Number 
+
+```shell
+  curl "https://api.geocod.io/v1.7/geocode?q=2800+Clarendon+Blvd+Suite+R500+Arlington+VA+22201&api_key=YOUR_API_KEY"
+```
+
+> Example response with Suite/Apartment Number
+
+```json
+{
+  "input": {
+    "address_components": {
+      "number": "2800",
+      "street": "Clarendon",
+      "suffix": "Blvd",
+      "secondaryunit": "Ste",
+      "secondarynumber": "R500",
+      "formatted_street": "Clarendon Blvd",
+      "city": "Arlington",
+      "state": "VA",
+      "zip": "22201",
+      "country": "US"
+    },
+    "formatted_address": "2800 Clarendon Blvd, Ste 500, Arlington, VA 22201"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "2800",
+        "street": "Clarendon",
+        "suffix": "Blvd",
+        "secondaryunit": "Ste",
+        "secondarynumber": "R500",
+        "formatted_street": "Clarendon Blvd",
+        "city": "Arlington",
+        "county": "Arlington County",
+        "state": "VA",
+        "zip": "22201",
+        "country": "US"
+      },
+      "formatted_address": "2800 Clarendon Blvd, Ste R500, Arlington, VA 22201",
+      "location": {
+        "lat": 38.887455,
+        "lng": -77.092018
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Arlington"
+    }
+  ]
+}
+```
+
+**Suite/Apartment Secondary Unity Response**
+
+If you include an Apartment or Suite number along as a suffix to the street name, we will parse that number and return it as part of your response. It will be broken out into the `secondaryunit` and `secondarynumber` keys within `address_components`.
 
 ## Batch geocoding
 
@@ -1212,7 +1268,7 @@ Parameter | Description
 `limit`   | Optional parameter. The maximum number of results to return. The default is no limit.
 
 
-
+<!--DEFAULT
 # Geocoding lists
 
 The lists API lets you upload and process spreadsheet with addresses or coordinates. Similar to the [spreadsheet feature](https://www.geocod.io/upload/) in the dashboard, the spreadsheet will be processed as a job on Geocodio's infrastructure and can be downloaded at a later time. While a spreadsheet is being processed it is possible to query the status and progress.
@@ -1803,7 +1859,7 @@ The spreadsheet data will always be deleted automatically after 72 hours if it i
 Parameter | Description
 --------- | -----------
 `api_key` | Your Geocodio API key
-
+DEFAULT-->
 
 # Fields
 
@@ -2089,9 +2145,9 @@ Parameter name                                                                  
 
 <aside class="success">
 This feature is available for both single and batch geocoding requests
-
+<!--DEFAULT
 as well as the lists API
-
+DEFAULT-->
 </aside>
 
 ## Congressional Districts

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2352,6 +2352,9 @@ The field returns the full name of the Congressional district, the district numb
 The list of legislators is always ordered with Representative first then Senators.
 </aside>
 
+<aside class="notice">
+If you receive a response of 'Congressional District 0', that is because it is the official designation by the Census for states with only one Congressional district. Similarly, if you receive a response of 'Congressional District 98', this is in reference to districts with non-voting delegates.
+</aside>
 
 ### OCD Identifiers
 


### PR DESCRIPTION
Updated Docs to address two Github issues:
- [#323](https://github.com/Geocodio/geocodio/issues/323): Added example code for API call with address string that includes Suite/Apt Number. 
- [#260](https://github.com/Geocodio/geocodio/issues/260): Added note to explain what "Congressional District 0" or "Congressional District 98" mean in context of other districts. 